### PR TITLE
Refactor layout file.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,6 +256,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -310,6 +319,8 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "crossterm",
+ "itertools 0.13.0",
+ "paste",
  "rand",
  "ratatui",
 ]
@@ -435,7 +446,7 @@ dependencies = [
  "compact_str",
  "crossterm",
  "indoc",
- "itertools",
+ "itertools 0.12.1",
  "lru",
  "paste",
  "stability",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,6 @@ ratatui = { version = "0.26.2", features = ["all-widgets"]}
 crossterm = "0.27.0"  # ratatui dependency
 clap    = { version = "4.5.4", features = ["derive"]}
 rand = "0.8.5"
+itertools = "0.13.0"
+paste = "1.0.15"
 

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -1,4 +1,7 @@
 use std::collections::HashMap;
+use std::iter;
+
+use itertools::Itertools;
 
 pub enum Layout {
     Qwerty,
@@ -19,11 +22,16 @@ impl KbEmulator {
         let input_layout = get_layout(input);
         let output_layout = make_output_map(get_layout(output));
 
-        KbEmulator { input_layout, output_layout, }
+        KbEmulator {
+            input_layout,
+            output_layout,
+        }
     }
 
     pub fn translate(&self, input: char) -> Option<char> {
-        self.input_layout.get(&input).map(|&v| self.output_layout[&v])
+        self.input_layout
+            .get(&input)
+            .map(|&v| self.output_layout[&v])
     }
 }
 
@@ -43,376 +51,163 @@ fn get_layout(layout: Layout) -> HashMap<char, u8> {
 }
 
 pub fn get_layout_string(layout: &Layout) -> String {
-    let string_repr = match layout {
-        Layout::Qwerty => {
-            "┌───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┐
-│ Q │ W │ E │ R │ T │ Y │ U │ I │ O │ P │ [ │ ] │
-└┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┘
- │ A │ S │ D │ F │ G │ H │ J │ K │ L │ ; │ ' │
- └┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┘
-  │ Z │ X │ C │ V │ B │ N │ M │ , │ . │ / │
-  └───┴───┴───┴───┴───┴───┴───┴───┴───┴───┘".to_string()
+    match layout {
+        Layout::Qwerty => render_qwerty(),
+        Layout::Qwertz => render_qwertz(),
+        Layout::Azerty => render_azerty(),
+        Layout::Dvorak => render_dvorak(),
+        Layout::Colemak => render_colemak(),
+        Layout::ColemakDH => render_colemak_dh(),
+    }
+}
+
+fn render_map(map: &[char]) -> String {
+    let mut rows = Vec::new();
+    // Newline is used as a marker for rows of keys. It is safe since it is not a valid key.
+    for (_, chunk) in &map.iter().chunk_by(|elt| **elt != '\n') {
+        let row: Vec<char> = chunk.copied().collect();
+        // chunk by will leave one element chunks of the newline character. Skip these.
+        if row.len() > 1 {
+            rows.push(row);
         }
-        Layout::Qwertz => {
-            "┌───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┐
-│ Q │ W │ E │ R │ T │ Z │ U │ I │ O │ P │ Ü │ + │
-└┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┘
- │ A │ S │ D │ F │ G │ H │ J │ K │ L │ Ö │ Ä │
- └┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┘
-  │ Y │ X │ C │ V │ B │ N │ M │ , │ . │ - │
-  └───┴───┴───┴───┴───┴───┴───┴───┴───┴───┘".to_string()
+    }
+
+    // Now that the rows of keys have been collected they can be processed.
+    // Having the rows pre-processed enables the logic below to use the row count
+    // instead of hard coding anything.
+
+    let mut lines: Vec<String> = Vec::new();
+
+    // The first line is skipped because the number rows are not used or shown.
+    for (row_index, row) in rows.iter().enumerate().skip(1) {
+        // First row gets the "cap".
+        if row_index == 1 {
+            let line = "┌"
+                .chars()
+                .chain(
+                    iter::repeat(['─', '─', '─', '┬'])
+                        .take(row.len() - 1)
+                        .flatten(),
+                )
+                .chain(['─', '─', '─', '┐'])
+                .collect();
+            lines.push(line);
         }
-        Layout::Azerty => {
-            "┌───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┐
-│ A │ Z │ E │ R │ T │ Y │ U │ I │ O │ P │ ^ │ $ │
-└┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┘
- │ Q │ S │ D │ F │ G │ H │ J │ K │ L │ M │ ù │
- └┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┘
-  │ W │ X │ C │ V │ B │ N │ , │ ; │ : │ ! │
-  └───┴───┴───┴───┴───┴───┴───┴───┴───┴───┘".to_string()
+
+        let line: String = row
+            .iter()
+            .flat_map(|c| ['│', ' ', *c, ' '])
+            .chain(['│'])
+            .collect();
+        lines.push(format!("{}{line}", " ".repeat(row_index - 1)));
+
+        // Every row but the last one has connectors to the next row.
+        let connector = if row_index == rows.len() - 1 {
+            '─'
+        } else {
+            '┬'
+        };
+        let line: String = "└"
+            .chars()
+            .chain(
+                iter::repeat([connector, '─', '─', '┴'])
+                    .take(row.len() - 1)
+                    .flatten(),
+            )
+            .chain([connector, '─', '─', '┘'])
+            .collect();
+        lines.push(format!("{}{line}", " ".repeat(row_index - 1)));
+    }
+    lines.join("\n")
+}
+
+fn make_keymap(map: &[char]) -> HashMap<char, u8> {
+    map.iter()
+        .enumerate()
+        .map(|(index, key)| (*key, (index + 1) as u8))
+        .collect()
+}
+
+macro_rules! layout {
+    // layout name and array of keys
+    ($func_name:ident, $keymap:expr) => {
+        fn $func_name() -> HashMap<char, u8> {
+            make_keymap(&$keymap)
         }
-        Layout::Dvorak => {
-            "┌───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┐
-│ ' │ , │ . │ P │ Y │ F │ G │ C │ R │ L │ / │ = │
-└┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┘
- │ A │ O │ E │ U │ I │ D │ H │ T │ N │ S │ - │
- └┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┘
-  │ ; │ Q │ J │ K │ X │ B │ M │ W │ V │ Z │
-  └───┴───┴───┴───┴───┴───┴───┴───┴───┴───┘".to_string()
-        }
-        Layout::Colemak => {
-            "┌───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┐
-│ Q │ W │ F │ P │ G │ J │ L │ U │ Y │ ; │ [ │ ] │
-└┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┘
- │ A │ R │ S │ T │ D │ H │ N │ E │ I │ O │ ' │
- └┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┘
-  │ Z │ X │ C │ V │ B │ K │ M │ , │ . │ / │
-  └───┴───┴───┴───┴───┴───┴───┴───┴───┴───┘".to_string()
-        }
-        Layout::ColemakDH => {
-            "┌───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┬───┐
-│ Q │ W │ F │ P │ B │ J │ L │ U │ Y │ ; │ [ │ ] │
-└┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┘
- │ A │ R │ S │ T │ G │ M │ N │ E │ I │ O │ ' │
- └┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┴┬──┘
-  │ Z │ X │ C │ D │ V │ K │ H │ , │ . │ / │
-  └───┴───┴───┴───┴───┴───┴───┴───┴───┴───┘".to_string()
+
+        paste::item! {
+            fn [< render_ $func_name >] () -> String {
+                render_map(&$keymap)
+            }
         }
     };
-    string_repr
 }
 
-// Returs the QWERTY layout, including symbols on the base layer.
-fn qwerty() -> HashMap<char, u8> {
-    let mut layout = HashMap::new();
-    layout.insert('1', 1);
-    layout.insert('2', 2);
-    layout.insert('3', 3);
-    layout.insert('4', 4);
-    layout.insert('5', 5);
-    layout.insert('6', 6);
-    layout.insert('7', 7);
-    layout.insert('8', 8);
-    layout.insert('9', 9);
-    layout.insert('0', 10);
-    layout.insert('-', 11);
-    layout.insert('=', 12);
-    layout.insert('q', 13);
-    layout.insert('w', 14);
-    layout.insert('e', 15);
-    layout.insert('r', 16);
-    layout.insert('t', 17);
-    layout.insert('y', 18);
-    layout.insert('u', 19);
-    layout.insert('i', 20);
-    layout.insert('o', 21);
-    layout.insert('p', 22);
-    layout.insert('[', 23);
-    layout.insert(']', 24);
-    //layout.insert('\\',25); // we ignore this key since it is not relevant for layout emulation and only exists on ANSI keyboards
-    layout.insert('a', 25);
-    layout.insert('s', 26);
-    layout.insert('d', 27);
-    layout.insert('f', 28);
-    layout.insert('g', 29);
-    layout.insert('h', 30);
-    layout.insert('j', 31);
-    layout.insert('k', 32);
-    layout.insert('l', 33);
-    layout.insert(';', 34);
-    layout.insert('\'',35);
-    layout.insert('z', 36);
-    layout.insert('x', 37);
-    layout.insert('c', 38);
-    layout.insert('v', 39);
-    layout.insert('b', 40);
-    layout.insert('n', 41);
-    layout.insert('m', 42);
-    layout.insert(',', 43);
-    layout.insert('.', 44);
-    layout.insert('/', 45);
-    layout.insert(' ', 46);
-    layout
+layout! {
+    qwerty,
+    [
+        '1', '2', '3', '4', '5', '6', '7', '8', '9', '0', '-', '=', '\n',
+        'q', 'w', 'e', 'r', 't', 'y', 'u', 'i', 'o', 'p', '[', ']', '\n',
+        'a', 's', 'd', 'f', 'g', 'h', 'j', 'k', 'l', ';', '\'', '\n',
+        'z', 'x', 'c', 'v', 'b', 'n', 'm', ',', '.', '/', '\n',
+        ' ',
+    ]
 }
 
-fn qwertz() -> HashMap<char, u8> {
-    let mut layout = HashMap::new();
-    layout.insert('1', 1);
-    layout.insert('2', 2);
-    layout.insert('3', 3);
-    layout.insert('4', 4);
-    layout.insert('5', 5);
-    layout.insert('6', 6);
-    layout.insert('7', 7);
-    layout.insert('8', 8);
-    layout.insert('9', 9);
-    layout.insert('0', 10);
-    layout.insert('ß', 11);
-    layout.insert('´', 12);
-    layout.insert('q', 13);
-    layout.insert('w', 14);
-    layout.insert('e', 15);
-    layout.insert('r', 16);
-    layout.insert('t', 17);
-    layout.insert('z', 18);
-    layout.insert('u', 19);
-    layout.insert('i', 20);
-    layout.insert('o', 21);
-    layout.insert('p', 22);
-    layout.insert('ü', 23);
-    layout.insert('+', 24);
-    layout.insert('a', 25);
-    layout.insert('s', 26);
-    layout.insert('d', 27);
-    layout.insert('f', 28);
-    layout.insert('g', 29);
-    layout.insert('h', 30);
-    layout.insert('j', 31);
-    layout.insert('k', 32);
-    layout.insert('l', 33);
-    layout.insert('ö', 34);
-    layout.insert('ä', 35);
-    //layout.insert('\'', 36); // we ignore this key since it is not relevant for layout emulation and only exists on ISO keyboards
-    //layout.insert('<', 36); // we ignore this key since it is not relevant for layout emulation and only exists on ISO keyboards
-    layout.insert('y', 36);
-    layout.insert('x', 37);
-    layout.insert('c', 38);
-    layout.insert('v', 39);
-    layout.insert('b', 40);
-    layout.insert('n', 41);
-    layout.insert('m', 42);
-    layout.insert(',', 43);
-    layout.insert('.', 44);
-    layout.insert('-', 45);
-    layout.insert(' ', 46);
-    layout
+// Keys that are not relevant and only on ANSI or ISO keyboards are not represented.
+
+layout! {
+    qwertz,
+    [
+        '1', '2', '3', '4', '5', '6', '7', '8', '9', '0', 'ß', '´', '\n',
+        'q', 'w', 'e', 'r', 't', 'z', 'u', 'i', 'o', 'p', 'ü', '+', '\n',
+        'a', 's', 'd', 'f', 'g', 'h', 'j', 'k', 'l', 'ö', 'ä', '\n',
+        'y', 'x', 'c', 'v', 'b', 'n', 'm', ',', '.', '-', '\n',
+        ' ',
+    ]
 }
 
-fn azerty() -> HashMap<char, u8> {
-    let mut layout = HashMap::new();
-    // yes, the french have numbers on the shift layer
-    layout.insert('&', 1); // '1' key on QWERTY
-    layout.insert('é', 2); // '2' key on QWERTY
-    layout.insert('"', 3); // '3' key on QWERTY
-    layout.insert('\'', 4); // '4' key on QWERTY
-    layout.insert('(', 5); // '5' key on QWERTY
-    layout.insert('-', 6); // '6' key on QWERTY
-    layout.insert('è', 7); // '7' key on QWERTY
-    layout.insert('_', 8); // '8' key on QWERTY
-    layout.insert('ç', 9); // '9' key on QWERTY
-    layout.insert('à', 10); // '0' key on QWERTY
-    layout.insert(')', 11); // '-' key on QWERTY
-    layout.insert('=', 12); // '=' key on QWERTY
-    layout.insert('a', 13); // 'q' key on QWERTY
-    layout.insert('z', 14); // 'w' key on QWERTY
-    layout.insert('e', 15);
-    layout.insert('r', 16);
-    layout.insert('t', 17);
-    layout.insert('y', 18);
-    layout.insert('u', 19);
-    layout.insert('i', 20);
-    layout.insert('o', 21);
-    layout.insert('p', 22);
-    layout.insert('^', 23); // '[' key on QWERTY
-    layout.insert('$', 24); // ']' key on QWERTY
-    //layout.insert('\\', 25); // we ignore this key since it is not relevant for layout emulation and only exists on ANSI keyboards
-    layout.insert('q', 25); // 'a' key on QWERTY
-    layout.insert('s', 26);
-    layout.insert('d', 27);
-    layout.insert('f', 28);
-    layout.insert('g', 29);
-    layout.insert('h', 30);
-    layout.insert('j', 31);
-    layout.insert('k', 32);
-    layout.insert('l', 33);
-    layout.insert('m', 34); // ';' key on QWERTY
-    layout.insert('ù', 35); // '\'' key on QWERTY
-    //layout.insert('*', 37); // we ignore this key since it is not relevant for layout emulation and only exists on ISO keyboards
-    layout.insert('w', 36); // 'z' key on QWERTY
-    layout.insert('x', 37);
-    layout.insert('c', 38);
-    layout.insert('v', 39);
-    layout.insert('b', 40);
-    layout.insert('n', 41);
-    layout.insert(',', 42);
-    layout.insert(';', 43);
-    layout.insert(':', 44);
-    layout.insert('!', 45);
-    layout.insert(' ', 46);
-    layout
+layout! {
+    azerty,
+    [
+        // yes, the French have numbers on the shift layer
+        '&', 'é', '"', '\'', '(', '-', 'è', '_', 'ç', 'à', ')', '=', '\n',
+        'a', 'z', 'e', 'r', 't', 'y', 'u', 'i', 'o', 'p', '^', '$', '\n',
+        'q', 's', 'd', 'f', 'g', 'h', 'j', 'k', 'l', 'm', 'ù', '\n',
+        'w', 'x', 'c', 'v', 'b', 'n', ',', ';', ':', '!', '\n',
+        ' ',
+    ]
 }
 
-fn dvorak() -> HashMap<char, u8> {
-    let mut layout = HashMap::new();
-    layout.insert('1', 1);
-    layout.insert('2', 2);
-    layout.insert('3', 3);
-    layout.insert('4', 4);
-    layout.insert('5', 5);
-    layout.insert('6', 6);
-    layout.insert('7', 7);
-    layout.insert('8', 8);
-    layout.insert('9', 9);
-    layout.insert('0', 10);
-    layout.insert('[', 11);
-    layout.insert(']', 12);
-    layout.insert('\'', 13);
-    layout.insert(',', 14);
-    layout.insert('.', 15);
-    layout.insert('p', 16);
-    layout.insert('y', 17);
-    layout.insert('f', 18);
-    layout.insert('g', 19);
-    layout.insert('c', 20);
-    layout.insert('r', 21);
-    layout.insert('l', 22);
-    layout.insert('/', 23);
-    layout.insert('=', 24);
-    layout.insert('a', 25);
-    layout.insert('o', 26);
-    layout.insert('e', 27);
-    layout.insert('u', 28);
-    layout.insert('i', 29);
-    layout.insert('d', 30);
-    layout.insert('h', 31);
-    layout.insert('t', 32);
-    layout.insert('n', 33);
-    layout.insert('s', 34);
-    layout.insert('-', 35);
-    layout.insert(';', 36);
-    layout.insert('q', 37);
-    layout.insert('j', 38);
-    layout.insert('k', 39);
-    layout.insert('x', 40);
-    layout.insert('b', 41);
-    layout.insert('m', 42);
-    layout.insert('w', 43);
-    layout.insert('v', 44);
-    layout.insert('z', 45);
-    layout.insert(' ', 46);
-    layout
+layout! {
+    dvorak,
+    [
+        '1', '2', '3', '4', '5', '6', '7', '8', '9', '0', '[', ']', '\n',
+        '\'', ',', '.', 'p', 'y', 'f', 'g', 'c', 'r', 'l', '/', '=', '\n',
+        'a', 'o', 'e', 'u', 'i', 'd', 'h', 't', 'n', 's', '-', '\n',
+        ';', 'q', 'j', 'k', 'x', 'b', 'm', 'w', 'v', 'z', '\n',
+        ' ',
+    ]
 }
 
-fn colemak() -> HashMap<char, u8> {
-    let mut layout = HashMap::new();
-    layout.insert('1', 1);
-    layout.insert('2', 2);
-    layout.insert('3', 3);
-    layout.insert('4', 4);
-    layout.insert('5', 5);
-    layout.insert('6', 6);
-    layout.insert('7', 7);
-    layout.insert('8', 8);
-    layout.insert('9', 9);
-    layout.insert('0', 10);
-    layout.insert('-', 11);
-    layout.insert('=', 12);
-    layout.insert('q', 13);
-    layout.insert('w', 14);
-    layout.insert('f', 15);
-    layout.insert('p', 16);
-    layout.insert('g', 17);
-    layout.insert('j', 18);
-    layout.insert('l', 19);
-    layout.insert('u', 20);
-    layout.insert('y', 21);
-    layout.insert(';', 22);
-    layout.insert('[', 23);
-    layout.insert(']', 24);
-    layout.insert('a', 25);
-    layout.insert('r', 26);
-    layout.insert('s', 27);
-    layout.insert('t', 28);
-    layout.insert('d', 29);
-    layout.insert('h', 30);
-    layout.insert('n', 31);
-    layout.insert('e', 32);
-    layout.insert('i', 33);
-    layout.insert('o', 34);
-    layout.insert('\'',35);
-    layout.insert('z', 36);
-    layout.insert('x', 37);
-    layout.insert('c', 38);
-    layout.insert('v', 39);
-    layout.insert('b', 40);
-    layout.insert('k', 41);
-    layout.insert('m', 42);
-    layout.insert(',', 43);
-    layout.insert('.', 44);
-    layout.insert('/', 45);
-    layout.insert(' ', 46);
-    layout
+layout! {
+    colemak,
+    [
+        '1', '2', '3', '4', '5', '6', '7', '8', '9', '0', '-', '=', '\n',
+        'q', 'w', 'f', 'p', 'g', 'j', 'l', 'u', 'y', ';', '[', ']', '\n',
+        'a', 'r', 's', 't', 'd', 'h', 'n', 'e', 'i', 'o', '\'', '\n',
+        'z', 'x', 'c', 'v', 'b', 'k', 'm', ',', '.', '/', '\n',
+        ' ',
+    ]
 }
 
-fn colemak_dh() -> HashMap<char, u8> {
-    let mut layout = HashMap::new();
-    layout.insert('1', 1);
-    layout.insert('2', 2);
-    layout.insert('3', 3);
-    layout.insert('4', 4);
-    layout.insert('5', 5);
-    layout.insert('6', 6);
-    layout.insert('7', 7);
-    layout.insert('8', 8);
-    layout.insert('9', 9);
-    layout.insert('0', 10);
-    layout.insert('-', 11);
-    layout.insert('=', 12);
-    layout.insert('q', 13);
-    layout.insert('w', 14);
-    layout.insert('f', 15);
-    layout.insert('p', 16);
-    layout.insert('b', 17);
-    layout.insert('j', 18);
-    layout.insert('l', 19);
-    layout.insert('u', 20);
-    layout.insert('y', 21);
-    layout.insert(';', 22);
-    layout.insert('[', 23);
-    layout.insert(']', 24);
-    layout.insert('a', 25);
-    layout.insert('r', 26);
-    layout.insert('s', 27);
-    layout.insert('t', 28);
-    layout.insert('g', 29);
-    layout.insert('m', 30);
-    layout.insert('n', 31);
-    layout.insert('e', 32);
-    layout.insert('i', 33);
-    layout.insert('o', 34);
-    layout.insert('\'',35);
-    layout.insert('z', 36);
-    layout.insert('x', 37);
-    layout.insert('c', 38);
-    layout.insert('d', 39);
-    layout.insert('v', 40);
-    layout.insert('k', 41);
-    layout.insert('h', 42);
-    layout.insert(',', 43);
-    layout.insert('.', 44);
-    layout.insert('/', 45);
-    layout.insert(' ', 46);
-    layout
+layout! {
+    colemak_dh,
+    [
+        '1', '2', '3', '4', '5', '6', '7', '8', '9', '0', '-', '=', '\n',
+        'q', 'w', 'f', 'p', 'b', 'j', 'l', 'u', 'y', ';', '[', ']', '\n',
+        'a', 'r', 's', 't', 'g', 'm', 'n', 'e', 'i', 'o', '\'', '\n',
+        'z', 'x', 'c', 'd', 'v', 'k', 'h', ',', '.', '/', '\n',
+        ' ',
+    ]
 }
-
-


### PR DESCRIPTION
This PR adds a macro which generates functions to parse and show the keyboard map. Instead of long lists of manual key indexes use enumerate(). This also allows the keyboards to be represented in a more natural manner. There is now a function to render the keyboard using the new layout format. "\n" is used to indicate end of row. I am considering using "\t" to define split keyboards in a follow on PR if this work is accepted. Also maybe an ortho render instead of the staggered style as an option.

These functions should make it possible to accept layouts as a command line parameter with a little more effort.

Two new crates were added. Itertools providers `chunk_by` which is used in the layout rendering and Paste which is used by the macro to glue together "render_" and the layout's name to generate the final function name. Unfortunately anything else needs nightly to my understanding.

I tried to limit the changes but a couple of formatting changes slipped through because my editor runs `cargo fmt` on save. Which is fairly typical for Rust projects.