### PR TITLE
Support ortholinear display of the keyboard.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,16 +62,21 @@ flags, but starts with the recommended defaults if unconfigured.
 
 Options:
 ```
---n <2|3|4|w|FILENAME>       use bigrams(2) trigrams(3) tetragrams(4) or words(w), or specify your own comma separated wordlist as a file.
---top <1-200>                use the top X ngrams ordered by usage.
---combi <1-200>              how many different ngrams to use in a single lesson.
---rep <number>               how often to repeat *each* different ngram in a lesson.
---wpm <number>               the wpm threshold at which the lesson is considered a success.
---acc <0-100>                the accuracy in percent at which the lesson is considered a success.
---emu-in <layout>            see section (## Layout Emulation).
---emu-out <layout>           see section (## Layout Emulation).
---nokb                       pass this flag to disable the keyboard layout display.
---cat                        the most important flag. don't practice alone.
+Usage: ngrrram [OPTIONS]
+
+Options:
+  -n, --n <2|3|4|w|file>  use bi-(2), tri-(3), tetragrams(4), (w)ords or comma separated wordlist file. [default: 2]
+  -t, --top <1-200>       use the top X ngrams ordered by usage. [default: 50]
+  -c, --combi <1-200>     how many different ngrams to use in a single lesson. [default: 2]
+  -r, --rep <number>      how often to repeat *each* different ngram in a lesson. [default: 3]
+  -w, --wpm <number>      the wpm threshold at which the lesson is considered a success. [default: 40]
+  -a, --acc <0-100>       the accuracy in percent at which the lesson is considered a success. [default: 94]
+      --emu-in <layout>   your current keyboard layout. only needed if you want to emulate a different layout. see docs for supported layouts. [default: ]
+      --emu-out <layout>  the layout you want to emulate. only needed if you want to emulate a different layout. see docs for supported layouts. [default: ]
+      --show-ortho        show keyboard in ortholinear format
+      --nokb              pass this flag to disable the keyboard layout display.
+      --cat               the most important flag. don't practice alone.
+  -h, --help              Print help
 ```
 
 If you start `ngrrram` without parameters, it uses these recommended defaults:

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -50,27 +50,39 @@ fn get_layout(layout: Layout) -> HashMap<char, u8> {
     }
 }
 
-pub fn get_layout_string(layout: &Layout) -> String {
-    match layout {
-        Layout::Qwerty => render_qwerty(),
-        Layout::Qwertz => render_qwertz(),
-        Layout::Azerty => render_azerty(),
-        Layout::Dvorak => render_dvorak(),
-        Layout::Colemak => render_colemak(),
-        Layout::ColemakDH => render_colemak_dh(),
-    }
+pub fn get_layout_string(layout: &Layout, show_ortho: bool) -> String {
+    let render = match layout {
+        Layout::Qwerty => render_qwerty,
+        Layout::Qwertz => render_qwertz,
+        Layout::Azerty => render_azerty,
+        Layout::Dvorak => render_dvorak,
+        Layout::Colemak => render_colemak,
+        Layout::ColemakDH => render_colemak_dh,
+    };
+    render(show_ortho)
 }
 
-fn render_map(map: &[char]) -> String {
+fn render_map(map: &[char], is_ortho: bool) -> String {
     let mut rows = Vec::new();
+    let mut max_row_length = 0;
+
     // Newline is used as a marker for rows of keys. It is safe since it is not a valid key.
     for (_, chunk) in &map.iter().chunk_by(|elt| **elt != '\n') {
         let row: Vec<char> = chunk.copied().collect();
-        // chunk by will leave one element chunks of the newline character. Skip these.
-        if row.len() > 1 {
+        let length = row.len();
+        // chunk_by will leave one element chunks of the newline character. Skip these.
+        if length > 1 {
             rows.push(row);
+            max_row_length = max_row_length.max(length);
         }
     }
+
+    let box_bottom = ('└', '─', '┴', '┘');
+    let box_normal = if is_ortho {
+        ('├', '─', '┼', '┤')
+    } else {
+        ('└', '┬', '┴', '┘')
+    };
 
     // Now that the rows of keys have been collected they can be processed.
     // Having the rows pre-processed enables the logic below to use the row count
@@ -80,45 +92,67 @@ fn render_map(map: &[char]) -> String {
 
     // The first line is skipped because the number rows are not used or shown.
     for (row_index, row) in rows.iter().enumerate().skip(1) {
-        // First row gets the "cap".
+        let column_count = if is_ortho { max_row_length } else { row.len() };
+
         if row_index == 1 {
-            let line = "┌"
-                .chars()
-                .chain(
-                    iter::repeat(['─', '─', '─', '┬'])
-                        .take(row.len() - 1)
-                        .flatten(),
-                )
-                .chain(['─', '─', '─', '┐'])
-                .collect();
-            lines.push(line);
+            let (begin, down, middle, end) = box_bottom;
+
+            // First row gets the "cap". Symbols are the inverse of the bottom.
+            lines.push(render_frame_row(
+                column_count,
+                char::from_u32(begin as u32 - 8).unwrap(),
+                down, // this one is good as is
+                char::from_u32(middle as u32 - 8).unwrap(),
+                char::from_u32(end as u32 - 8).unwrap(),
+            ));
         }
 
-        let line: String = row
-            .iter()
-            .flat_map(|c| ['│', ' ', *c, ' '])
-            .chain(['│'])
-            .collect();
-        lines.push(format!("{}{line}", " ".repeat(row_index - 1)));
+        let line = if is_ortho {
+            render_key_row(row.iter().pad_using(max_row_length, |_| &'△'))
+        } else {
+            let line = render_key_row(row.iter());
+            format!("{}{line}", " ".repeat(row_index - 1))
+        };
+        lines.push(line);
 
         // Every row but the last one has connectors to the next row.
-        let connector = if row_index == rows.len() - 1 {
-            '─'
+        let (begin, down, middle, end) = if row_index == rows.len() - 1 {
+            box_bottom
         } else {
-            '┬'
+            box_normal
         };
-        let line: String = "└"
-            .chars()
-            .chain(
-                iter::repeat([connector, '─', '─', '┴'])
-                    .take(row.len() - 1)
-                    .flatten(),
-            )
-            .chain([connector, '─', '─', '┘'])
-            .collect();
-        lines.push(format!("{}{line}", " ".repeat(row_index - 1)));
+        let line = render_frame_row(column_count, begin, down, middle, end);
+        if is_ortho {
+            lines.push(line);
+        } else {
+            lines.push(format!("{}{line}", " ".repeat(row_index - 1)));
+        }
     }
     lines.join("\n")
+}
+
+fn render_frame_row(
+    column_count: usize,
+    begin: char,
+    down: char,
+    middle: char,
+    end: char,
+) -> String {
+    [begin]
+        .into_iter()
+        .chain(
+            iter::repeat([down, '─', '─', middle])
+                .take(column_count - 1) // one less to account for the final box with the end connector.
+                .flatten(),
+        )
+        .chain([down, '─', '─', end])
+        .collect()
+}
+
+fn render_key_row<'a>(iter: impl Iterator<Item = &'a char>) -> String {
+    iter.flat_map(|c| ['│', ' ', *c, ' '])
+        .chain(['│'])
+        .collect()
 }
 
 fn make_keymap(map: &[char]) -> HashMap<char, u8> {
@@ -136,8 +170,8 @@ macro_rules! layout {
         }
 
         paste::item! {
-            fn [< render_ $func_name >] () -> String {
-                render_map(&$keymap)
+            fn [< render_ $func_name >] (show_ortho: bool) -> String {
+                render_map(&$keymap, show_ortho)
             }
         }
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,71 +1,103 @@
 use clap::Parser;
 
-mod tui;
-mod game;
-mod ngrams;
-mod layout;
 mod cat;
+mod game;
+mod layout;
+mod ngrams;
+mod tui;
 
 #[derive(Parser)]
 //#[command(author, version, about, long_about = None)]
 struct Args {
-
-    #[arg(short, long, default_value = "2",
+    #[arg(
+        short,
+        long,
+        default_value = "2",
         value_name = "2|3|4|w|file",
         help = "use bi-(2), tri-(3), tetragrams(4), (w)ords or comma separated wordlist file."
     )]
     n: String,
 
-    #[arg(short, long, default_value = "50",
+    #[arg(
+        short,
+        long,
+        default_value = "50",
         value_name = "1-200",
         help = "use the top X ngrams ordered by usage."
     )]
     top: i32,
 
-    #[arg(short, long, default_value = "2",
+    #[arg(
+        short,
+        long,
+        default_value = "2",
         value_name = "1-200",
         help = "how many different ngrams to use in a single lesson."
     )]
     combi: i32,
 
-    #[arg(short, long, default_value = "3",
+    #[arg(
+        short,
+        long,
+        default_value = "3",
         value_name = "number",
         help = "how often to repeat *each* different ngram in a lesson."
     )]
     rep: i32,
 
-    #[arg(short, long, default_value = "40",
+    #[arg(
+        short,
+        long,
+        default_value = "40",
         value_name = "number",
         help = "the wpm threshold at which the lesson is considered a success."
     )]
     wpm: i32,
 
-    #[arg(short, long, default_value = "94",
+    #[arg(
+        short,
+        long,
+        default_value = "94",
         value_name = "0-100",
         help = "the accuracy in percent at which the lesson is considered a success."
     )]
     acc: i32,
 
-    #[arg(long, action, default_value = "",
+    #[arg(
+        long,
+        action,
+        default_value = "",
         value_name = "layout",
         help = "your current keyboard layout. only needed if you want to emulate a different layout. see docs for supported layouts."
     )]
     emu_in: String,
 
-    #[arg(long, action, default_value = "",
+    #[arg(
+        long,
+        action,
+        default_value = "",
         value_name = "layout",
         help = "the layout you want to emulate. only needed if you want to emulate a different layout. see docs for supported layouts."
     )]
     emu_out: String,
 
-    #[arg(long, action,
+    #[arg(
+        long,
+        action,
+        default_value = "false",
+        value_name = "bool",
+        help = "show keyboard in ortholinear format"
+    )]
+    show_ortho: bool,
+
+    #[arg(
+        long,
+        action,
         help = "pass this flag to disable the keyboard layout display."
     )]
     nokb: bool,
 
-    #[arg(long, action,
-        help = "the most important flag. don't practice alone."
-    )]
+    #[arg(long, action, help = "the most important flag. don't practice alone.")]
     cat: bool,
 }
 
@@ -160,9 +192,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "dvorak" => layout::Layout::Dvorak,
         "colemak" => layout::Layout::Colemak,
         "colemakdh" => layout::Layout::ColemakDH,
-        &_ => {
-            layout::Layout::Qwerty
-        }
+        &_ => layout::Layout::Qwerty,
     };
     let out_layout = match args.emu_out.as_str() {
         "qwerty" => layout::Layout::Qwerty,
@@ -171,11 +201,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "dvorak" => layout::Layout::Dvorak,
         "colemak" => layout::Layout::Colemak,
         "colemakdh" => layout::Layout::ColemakDH,
-        &_ => {
-            layout::Layout::Qwerty
-        }
+        &_ => layout::Layout::Qwerty,
     };
-    let out_layout_string = layout::get_layout_string(&out_layout);
+    let out_layout_string = layout::get_layout_string(&out_layout, args.show_ortho);
 
     let mut state = AppState {
         current_lesson_number: 0,
@@ -226,7 +254,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             cat_timer = std::time::Duration::from_millis(0);
             cat_frame = cat_iter.next().expect("cat frame not found").to_string();
         }
-
     }
 
     tui::cleanup_tui()?;


### PR DESCRIPTION
This PR adds a --show-ortho parameter and refactors the `render_map` function to support both staggered and ortholinear with staggered remaining the default.

I chose "△" to fill in the ortho when there were empty spaces. It looked better I think but it was also completely arbitrary.

The diff is a little messy, might be easier to do a side by side.

![Screenshot 2024-05-28 at 5 21 14 PM](https://github.com/wintermute-cell/ngrrram/assets/1377996/ec5bc34d-ce70-4f37-a982-a5af3ed4ec60)